### PR TITLE
Implement Entrant Event Details and Join/Leave Waitlist

### DIFF
--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
         <activity
             android:name=".ui.AuthActivity"
             android:exported="false" />
+        <activity
+            android:name=".ui.EventDetailsActivity"
+            android:exported="false" />
 
     </application>
 </manifest>

--- a/code/app/src/main/java/com/example/fairchance/models/Event.java
+++ b/code/app/src/main/java/com/example/fairchance/models/Event.java
@@ -26,6 +26,7 @@ public class Event {
     private double price;
     private boolean geolocationRequired;
     private long waitingListLimit;
+    private String guidelines; // <-- ADDED THIS FIELD
 
     // --- Utility Fields ---
 
@@ -136,6 +137,16 @@ public class Event {
     public void setWaitingListLimit(long waitingListLimit) {
         this.waitingListLimit = waitingListLimit;
     }
+
+    // --- ADDED GETTERS AND SETTERS FOR GUIDELINES ---
+    public String getGuidelines() {
+        return guidelines;
+    }
+
+    public void setGuidelines(String guidelines) {
+        this.guidelines = guidelines;
+    }
+    // --- END ADDED SECTION ---
 
     @Exclude
     public String getEventId() {

--- a/code/app/src/main/java/com/example/fairchance/ui/EventDetailsActivity.java
+++ b/code/app/src/main/java/com/example/fairchance/ui/EventDetailsActivity.java
@@ -1,0 +1,253 @@
+package com.example.fairchance.ui;
+
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import com.example.fairchance.EventRepository;
+import com.example.fairchance.R;
+import com.example.fairchance.models.Event;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public class EventDetailsActivity extends AppCompatActivity {
+
+    private static final String TAG = "EventDetailsActivity";
+
+    private EventRepository eventRepository;
+    private String currentEventId;
+    private Event currentEvent; // <-- ADDED: To hold the loaded event
+    private String currentEventStatus = null; // <-- ADDED: To track user's status
+
+    // UI Components
+    private ImageView eventPosterImage;
+    private ProgressBar progressBar;
+    private LinearLayout eventDetailsContent;
+    private TextView tvEventName, tvEventDate, tvEventDescription, tvEventGuidelines, tvEventWaitlistCount;
+    private Button btnJoinWaitlist;
+    private ProgressBar joinProgressBar; // <-- ADDED: For the button
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_event_details);
+
+        eventRepository = new EventRepository();
+
+        // Get Event ID from Intent
+        currentEventId = getIntent().getStringExtra("EVENT_ID");
+        if (currentEventId == null) {
+            Log.e(TAG, "Event ID is null. Finishing activity.");
+            Toast.makeText(this, "Error: Event not found.", Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+
+        // Find Views
+        eventPosterImage = findViewById(R.id.event_poster_image);
+        progressBar = findViewById(R.id.event_details_progress);
+        eventDetailsContent = findViewById(R.id.event_details_content);
+        tvEventName = findViewById(R.id.event_name_text);
+        tvEventDate = findViewById(R.id.event_date_text);
+        tvEventDescription = findViewById(R.id.event_description_text);
+        tvEventGuidelines = findViewById(R.id.event_guidelines_text);
+        tvEventWaitlistCount = findViewById(R.id.event_waitlist_count_text);
+        btnJoinWaitlist = findViewById(R.id.join_waitlist_button);
+        joinProgressBar = findViewById(R.id.join_progress); // <-- ADDED
+
+        // Load data
+        loadEventDetails();
+
+        // --- ADDED CLICK LISTENER ---
+        btnJoinWaitlist.setOnClickListener(v -> {
+            if (currentEventStatus == null) {
+                joinWaitlist();
+            } else if ("Waiting".equals(currentEventStatus)) {
+                leaveWaitlist();
+            }
+        });
+    }
+
+    private void loadEventDetails() {
+        setLoading(true);
+        // 1. Load main event data
+        eventRepository.getEvent(currentEventId, new EventRepository.EventCallback() {
+            @Override
+            public void onSuccess(Event event) {
+                currentEvent = event; // <-- ADDED: Store event
+                populateUi(event);
+
+                // 2. After getting event, load waitlist count
+                loadWaitlistCount();
+
+                // 3. --- ADDED --- Check the user's status for this event
+                checkUserStatus();
+            }
+
+            @Override
+            public void onError(String message) {
+                setLoading(false);
+                Log.e(TAG, "Error loading event: " + message);
+                Toast.makeText(EventDetailsActivity.this, "Failed to load event.", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void loadWaitlistCount() {
+        eventRepository.getWaitingListCount(currentEventId, new EventRepository.WaitlistCountCallback() {
+            @Override
+            public void onSuccess(int count) {
+                tvEventWaitlistCount.setText(count + " people");
+                // Don't call setLoading here, wait for checkUserStatus
+            }
+
+            @Override
+            public void onError(String message) {
+                Log.e(TAG, "Error loading waitlist count: " + message);
+                tvEventWaitlistCount.setText("Error loading count");
+                // Don't call setLoading here, wait for checkUserStatus
+            }
+        });
+    }
+
+    // --- ADDED NEW METHOD ---
+    private void checkUserStatus() {
+        eventRepository.checkEventHistoryStatus(currentEventId, new EventRepository.EventHistoryCheckCallback() {
+            @Override
+            public void onSuccess(String status) {
+                currentEventStatus = status;
+                updateJoinButtonUI();
+                setLoading(false); // Now we're done loading everything
+            }
+
+            @Override
+            public void onError(String message) {
+                Log.e(TAG, "Error checking user status: " + message);
+                setLoading(false); // Still need to stop loading
+            }
+        });
+    }
+
+    // --- ADDED NEW METHOD ---
+    private void joinWaitlist() {
+        if (currentEvent == null) {
+            Toast.makeText(this, "Event data not loaded yet.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        setButtonLoading(true);
+        eventRepository.joinWaitingList(currentEventId, currentEvent, new EventRepository.EventTaskCallback() {
+            @Override
+            public void onSuccess() {
+                setButtonLoading(false);
+                currentEventStatus = "Waiting";
+                updateJoinButtonUI();
+                Toast.makeText(EventDetailsActivity.this, "Joined waitlist!", Toast.LENGTH_SHORT).show();
+                loadWaitlistCount(); // Refresh count
+            }
+
+            @Override
+            public void onError(String message) {
+                setButtonLoading(false);
+                Toast.makeText(EventDetailsActivity.this, "Failed to join: " + message, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    // --- ADDED NEW METHOD ---
+    private void leaveWaitlist() {
+        setButtonLoading(true);
+        eventRepository.leaveWaitingList(currentEventId, new EventRepository.EventTaskCallback() {
+            @Override
+            public void onSuccess() {
+                setButtonLoading(false);
+                currentEventStatus = null;
+                updateJoinButtonUI();
+                Toast.makeText(EventDetailsActivity.this, "Left waitlist.", Toast.LENGTH_SHORT).show();
+                loadWaitlistCount(); // Refresh count
+            }
+
+            @Override
+            public void onError(String message) {
+                setButtonLoading(false);
+                Toast.makeText(EventDetailsActivity.this, "Failed to leave: " + message, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void populateUi(Event event) {
+        // Populate basic info
+        tvEventName.setText(event.getName());
+        tvEventDescription.setText(event.getDescription());
+
+        // Format the date
+        if (event.getEventDate() != null) {
+            SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, yyyy 'at' hh:mm a", Locale.getDefault());
+            tvEventDate.setText(sdf.format(event.getEventDate()));
+        } else {
+            tvEventDate.setText("Date not set");
+        }
+
+        // Populate guidelines
+        if (event.getGuidelines() != null && !event.getGuidelines().isEmpty()) {
+            tvEventGuidelines.setText(event.getGuidelines());
+        } else {
+            tvEventGuidelines.setText("No specific guidelines provided.");
+        }
+
+        // TODO: Load poster image with Glide or Picasso
+        // Glide.with(this).load(event.getPosterImageUrl()).into(eventPosterImage);
+    }
+
+    // --- ADDED NEW METHOD ---
+    private void updateJoinButtonUI() {
+        if ("Waiting".equals(currentEventStatus)) {
+            btnJoinWaitlist.setText("Leave Waitlist");
+            btnJoinWaitlist.setBackgroundTintList(ColorStateList.valueOf(Color.RED));
+            btnJoinWaitlist.setEnabled(true);
+        } else if (currentEventStatus == null) {
+            btnJoinWaitlist.setText("Join Waitlist");
+            btnJoinWaitlist.setBackgroundTintList(ColorStateList.valueOf(ContextCompat.getColor(this, R.color.FCgreen)));
+            btnJoinWaitlist.setEnabled(true);
+        } else {
+            // User is "Confirmed", "Selected", etc.
+            btnJoinWaitlist.setText("You are " + currentEventStatus);
+            btnJoinWaitlist.setBackgroundTintList(ColorStateList.valueOf(Color.GRAY));
+            btnJoinWaitlist.setEnabled(false);
+        }
+    }
+
+    private void setLoading(boolean isLoading) {
+        if (isLoading) {
+            progressBar.setVisibility(View.VISIBLE);
+            eventDetailsContent.setVisibility(View.GONE);
+        } else {
+            progressBar.setVisibility(View.GONE);
+            eventDetailsContent.setVisibility(View.VISIBLE);
+        }
+    }
+
+    // --- ADDED NEW METHOD ---
+    private void setButtonLoading(boolean isLoading) {
+        if (isLoading) {
+            joinProgressBar.setVisibility(View.VISIBLE);
+            btnJoinWaitlist.setText(""); // Hide text
+            btnJoinWaitlist.setEnabled(false);
+        } else {
+            joinProgressBar.setVisibility(View.GONE);
+            // The text will be reset by updateJoinButtonUI()
+            btnJoinWaitlist.setEnabled(true);
+        }
+    }
+}

--- a/code/app/src/main/java/com/example/fairchance/ui/adapters/EventAdapter.java
+++ b/code/app/src/main/java/com/example/fairchance/ui/adapters/EventAdapter.java
@@ -1,5 +1,7 @@
 package com.example.fairchance.ui.adapters;
 
+import android.content.Context;
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +12,8 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import com.example.fairchance.R;
 import com.example.fairchance.models.Event;
+import com.example.fairchance.ui.EventDetailsActivity; // <-- ADDED THIS IMPORT
+
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Locale;
@@ -70,9 +74,23 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHol
             // TODO: Load image with Glide or Picasso
             // Example: Glide.with(itemView.getContext()).load(event.getPosterImageUrl()).into(eventImage);
 
-            // TODO: Set click listeners for Join and Details
-            // buttonJoin.setOnClickListener(v -> ... );
-            // buttonDetails.setOnClickListener(v -> ... );
+
+            // --- START OF MODIFIED CODE ---
+
+            // Create the click listener to navigate to details
+            View.OnClickListener detailsClickListener = v -> {
+                Context context = itemView.getContext();
+                Intent intent = new Intent(context, EventDetailsActivity.class);
+                intent.putExtra("EVENT_ID", event.getEventId());
+                context.startActivity(intent);
+            };
+
+            // Set click listeners for Join, Details, and the whole card
+            buttonJoin.setOnClickListener(detailsClickListener);
+            buttonDetails.setOnClickListener(detailsClickListener);
+            itemView.setOnClickListener(detailsClickListener);
+
+            // --- END OF MODIFIED CODE ---
         }
     }
 }

--- a/code/app/src/main/res/layout/activity_event_details.xml
+++ b/code/app/src/main/res/layout/activity_event_details.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        tools:context=".ui.EventDetailsActivity">
+
+        <ImageView
+            android:id="@+id/event_poster_image"
+            android:layout_width="match_parent"
+            android:layout_height="250dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/fairchance_logo_with_words___transparent"
+            android:background="@color/light_gray_background" />
+
+        <ProgressBar
+            android:id="@+id/event_details_progress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="16dp"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+
+        <LinearLayout
+            android:id="@+id/event_details_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="24dp"
+            android:visibility="visible">
+
+            <TextView
+                android:id="@+id/event_name_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+                android:textStyle="bold"
+                android:textColor="@color/text_primary"
+                tools:text="Jazz in the Park" />
+
+            <TextView
+                android:id="@+id/event_date_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                android:textColor="@color/FCgreen"
+                tools:text="October 10 – 2:30 PM" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="16dp"
+                android:background="@color/light_gray_background" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Description"
+                android:textStyle="bold"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+            <TextView
+                android:id="@+id/event_description_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+                tools:text="A relaxing afternoon of smooth jazz from local bands. Bring your own blanket and enjoy the music." />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="Lottery Guidelines"
+                android:textStyle="bold"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+            <TextView
+                android:id="@+id/event_guidelines_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+                tools:text="Winners will be selected at random one week before the event. You must confirm your spot within 48 hours." />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="On the Waitlist"
+                android:textStyle="bold"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+            <TextView
+                android:id="@+id/event_waitlist_count_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+                tools:text="50 people" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:minHeight="32dp"/>
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="60dp">
+
+                <Button
+                    android:id="@+id/join_waitlist_button"
+                    style="@style/Widget.MaterialComponents.Button"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:text="Join Waitlist"
+                    android:textSize="16sp"/>
+
+                <ProgressBar
+                    android:id="@+id/join_progress"
+                    style="?android:attr/progressBarStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:elevation="8dp"
+                    android:indeterminateTint="@android:color/white"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+            </FrameLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
This PR completes the core functionality for an entrant to view and interact with an event, closing #<Issue-Number>.

### What's New
- **Event Details Screen:** A new `EventDetailsActivity` is created. It displays all event information from Firestore, including event name, date, description, and the new `guidelines` field.
- **Waitlist Count:** The details screen shows a live count of how many entrants are currently on the waitlist (implements `US 01.05.04`).
- **Join/Leave Logic:** The details screen features an intelligent button that:
  - Shows "Join Waitlist" (green) if the entrant is not on the list.
  - Shows "Leave Waitlist" (red) if the entrant is already on the list.
  - Shows a disabled "You are [Status]" (gray) button if their status is "Confirmed," "Selected," etc.
- **Navigation:** All event cards and "Join" buttons on the `EntrantHomeFragment` list now navigate to this details screen.

### Repository Changes
- `EventRepository` has been updated with new methods:
  - `leaveWaitingList`: Atomically removes a user from an event's waitlist and their own history.
  - `checkEventHistoryStatus`: A helper to check a user's status for a specific event.
- All "join" and "leave" operations use `WriteBatch` to ensure database consistency.