### PR TITLE
Implement Entrant Profile Settings, Image Loading, and FCM Notifications

### DIFF
--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -47,4 +47,6 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+    implementation("com.github.bumptech.glide:glide:4.16.0")
+    implementation("com.google.firebase:firebase-messaging")
 }

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
+
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:allowBackup="true"
@@ -47,5 +49,12 @@
             android:stateNotNeeded="true"
             tools:replace="android:screenOrientation" />
 
+        <service
+            android:name=".MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/code/app/src/main/java/com/example/fairchance/MyFirebaseMessagingService.java
+++ b/code/app/src/main/java/com/example/fairchance/MyFirebaseMessagingService.java
@@ -1,0 +1,87 @@
+package com.example.fairchance;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+public class MyFirebaseMessagingService extends FirebaseMessagingService {
+
+    private static final String TAG = "MyFirebaseMsgService";
+    private static final String CHANNEL_ID = "FAIR_CHANCE_CHANNEL";
+
+    /**
+     * Called when a new FCM registration token is generated.
+     */
+    @Override
+    public void onNewToken(@NonNull String token) {
+        Log.d(TAG, "Refreshed token: " + token);
+
+        // Save the token to Firestore
+        // We create a new instance here because this is a service
+        AuthRepository authRepository = new AuthRepository();
+        authRepository.saveFcmToken(token);
+    }
+
+    /**
+     * Called when a message is received.
+     */
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        Log.d(TAG, "From: " + remoteMessage.getFrom());
+
+        // Check if message contains a notification payload.
+        if (remoteMessage.getNotification() != null) {
+            String title = remoteMessage.getNotification().getTitle();
+            String body = remoteMessage.getNotification().getBody();
+            Log.d(TAG, "Notification Title: " + title);
+            Log.d(TAG, "Notification Body: " + body);
+
+            // Show the notification to the user
+            sendNotification(title, body);
+        }
+    }
+
+    /**
+     * Create and show a simple notification containing the received FCM message.
+     */
+    private void sendNotification(String messageTitle, String messageBody) {
+        // Create an intent that will open the app when the notification is tapped
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0 /* Request code */, intent,
+                PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(this, CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_invitations_nav) // Use an existing icon
+                        .setContentTitle(messageTitle)
+                        .setContentText(messageBody)
+                        .setAutoCancel(true)
+                        .setPriority(NotificationCompat.PRIORITY_HIGH)
+                        .setContentIntent(pendingIntent);
+
+        NotificationManager notificationManager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        // Since Android 8.0 (API 26), notification channels are required.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                    "FairChance Notifications",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        // Show the notification
+        notificationManager.notify(0 /* ID of notification */, notificationBuilder.build());
+    }
+}

--- a/code/app/src/main/java/com/example/fairchance/models/User.java
+++ b/code/app/src/main/java/com/example/fairchance/models/User.java
@@ -12,6 +12,7 @@ public class User {
     private String phone;
     private String role;
     private Map<String, Boolean> notificationPreferences;
+    private String fcmToken; // <-- ADD THIS
 
     // A no-argument constructor is required for Firestore
     public User() {}
@@ -22,4 +23,5 @@ public class User {
     public String getPhone() { return phone; }
     public String getRole() { return role; }
     public Map<String, Boolean> getNotificationPreferences() { return notificationPreferences; }
+    public String getFcmToken() { return fcmToken; } // <-- ADD THIS
 }

--- a/code/app/src/main/java/com/example/fairchance/ui/SplashActivity.java
+++ b/code/app/src/main/java/com/example/fairchance/ui/SplashActivity.java
@@ -1,14 +1,22 @@
 package com.example.fairchance.ui;
 
+import android.Manifest; // <-- ADD THIS
 import android.content.Intent;
+import android.content.pm.PackageManager; // <-- ADD THIS
+import android.os.Build; // <-- ADD THIS
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log; // <-- ADD THIS
+
+import androidx.core.app.ActivityCompat; // <-- ADD THIS
+import androidx.core.content.ContextCompat; // <-- ADD THIS
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.fairchance.MainActivity;
 import com.example.fairchance.R;
 import com.example.fairchance.AuthRepository;
 import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.messaging.FirebaseMessaging; // <-- ADD THIS
 
 /**
  * The main entry point (launcher) activity for the app.
@@ -18,6 +26,7 @@ import com.google.firebase.auth.FirebaseUser;
 public class SplashActivity extends AppCompatActivity {
 
     private static final long SPLASH_SCREEN_DELAY = 1500L;
+    private static final String TAG = "SplashActivity"; // <-- ADD THIS
     private AuthRepository authRepository;
 
     @Override
@@ -27,15 +36,60 @@ public class SplashActivity extends AppCompatActivity {
 
         authRepository = new AuthRepository();
 
+        // --- ADD THIS: REQUEST NOTIFICATION PERMISSION ---
+        requestNotificationPermission();
+        // --- END ADDED ---
+
         new Handler().postDelayed(() -> {
             FirebaseUser currentUser = authRepository.getCurrentUser();
             if (currentUser != null) {
+                // --- ADD THIS ---
+                // User is logged in, get/save token
+                getAndSaveFcmToken();
+                // --- END ADDED ---
                 goToMainApp();
             } else {
                 goToRoleSelection();
             }
         }, SPLASH_SCREEN_DELAY);
     }
+
+    // --- START: ADDED NEW METHODS ---
+    /**
+     * Requests the POST_NOTIFICATIONS permission on Android 13+
+     */
+    private void requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
+                    PackageManager.PERMISSION_GRANTED) {
+
+                // You can show a UI explaining why you need the permission here
+                // For now, we'll just request it
+                ActivityCompat.requestPermissions(this,
+                        new String[]{Manifest.permission.POST_NOTIFICATIONS}, 101);
+            }
+        }
+    }
+
+    /**
+     * Gets the current FCM token and saves it to the user's profile in Firestore.
+     */
+    private void getAndSaveFcmToken() {
+        FirebaseMessaging.getInstance().getToken()
+                .addOnCompleteListener(task -> {
+                    if (!task.isSuccessful()) {
+                        Log.w(TAG, "Fetching FCM registration token failed", task.getException());
+                        return;
+                    }
+                    // Get new FCM registration token
+                    String token = task.getResult();
+                    Log.d(TAG, "FCM Token: " + token);
+
+                    // Save it to Firestore
+                    authRepository.saveFcmToken(token);
+                });
+    }
+    // --- END: ADDED NEW METHODS ---
 
     private void goToMainApp() {
         Intent intent = new Intent(SplashActivity.this, MainActivity.class);

--- a/code/app/src/main/java/com/example/fairchance/ui/adapters/EventAdapter.java
+++ b/code/app/src/main/java/com/example/fairchance/ui/adapters/EventAdapter.java
@@ -6,29 +6,31 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.Filter; // <-- ADD THIS
-import android.widget.Filterable; // <-- ADD THIS
+import android.widget.Filter;
+import android.widget.Filterable;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide; // <-- ADD THIS IMPORT
 import com.example.fairchance.R;
 import com.example.fairchance.models.Event;
 import com.example.fairchance.ui.EventDetailsActivity;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList; // <-- ADD THIS
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHolder> implements Filterable { // <-- IMPLEMENTS FILTERABLE
+public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHolder> implements Filterable {
 
     private List<Event> eventList;
-    private List<Event> eventListFull; // <-- ADD THIS FOR FILTERING
+    private List<Event> eventListFull;
 
     public EventAdapter(List<Event> eventList) {
         this.eventList = eventList;
-        this.eventListFull = new ArrayList<>(eventList); // <-- INITIALIZE FULL LIST
+        this.eventListFull = new ArrayList<>(eventList);
     }
 
     @NonNull
@@ -49,15 +51,12 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHol
         return eventList.size();
     }
 
-    // --- ADDED: UPDATE METHOD FOR WHEN DATA FIRST LOADS ---
     public void setEvents(List<Event> events) {
         this.eventList = events;
         this.eventListFull = new ArrayList<>(events);
         notifyDataSetChanged();
     }
-    // --- END ADDED METHOD ---
 
-    // --- START: ADDED FILTER IMPLEMENTATION ---
     @Override
     public Filter getFilter() {
         return eventFilter;
@@ -91,7 +90,6 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHol
             notifyDataSetChanged();
         }
     };
-    // --- END: ADDED FILTER IMPLEMENTATION ---
 
 
     // ViewHolder class
@@ -115,14 +113,20 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.EventViewHol
 
             // Format the date
             if (event.getEventDate() != null) {
-                SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, yyyy 'at' hh:mm a", Locale.getDefault());
+                SimpleDateFormat sdf = new SimpleDateFormat("MMM dd, yyyY 'at' hh:mm a", Locale.getDefault());
                 eventDate.setText(sdf.format(event.getEventDate()));
             } else {
                 eventDate.setText("Date not set");
             }
 
-            // TODO: Load image with Glide or Picasso
-            // Example: Glide.with(itemView.getContext()).load(event.getPosterImageUrl()).into(eventImage);
+            // --- START: MODIFIED CODE ---
+            // Load image with Glide
+            Glide.with(itemView.getContext())
+                    .load(event.getPosterImageUrl())
+                    .placeholder(R.drawable.fairchance_logo_with_words___transparent) // Optional: show logo while loading
+                    .error(R.drawable.fairchance_logo_with_words___transparent) // Optional: show logo if it fails
+                    .into(eventImage);
+            // --- END: MODIFIED CODE ---
 
             // Create the click listener to navigate to details
             View.OnClickListener detailsClickListener = v -> {

--- a/code/app/src/main/res/layout/entrant_profile.xml
+++ b/code/app/src/main/res/layout/entrant_profile.xml
@@ -145,6 +145,31 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Notification Preferences"
+                android:textSize="16sp"
+                android:textColor="@color/text_primary"
+                android:textStyle="bold"
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="8dp" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_lottery_results"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Lottery Results"
+                android:textSize="16sp"
+                android:checked="true"/>
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_organizer_updates"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Organizer Updates"
+                android:textSize="16sp"
+                android:checked="true"/>
         </LinearLayout>
 
         <View


### PR DESCRIPTION
This PR completes the final two tasks for the Entrant role, rounding out the user-facing features.

### Closes #69 

### Description

This PR implements two major feature sets:

#### Task 5: Profile Notification Toggles (US 01.04.03)
- Adds "Lottery Results" and "Organizer Updates" toggles to the Profile screen.
- Uses `androidx.appcompat.widget.SwitchCompat` for compatibility.
- The user's choices are now loaded from Firestore on profile view and saved back to the `notificationPreferences` map when "Save Changes" is clicked.

#### Task 6: System-Wide Features (Image Loading & Notifications)
- **Image Loading:**
  - Integrates the Glide library.
  - Event posters are now loaded from URLs into the `ImageViews` on the home screen list (`EventAdapter`) and the `EventDetailsActivity`.

- **FCM Notifications (US 01.04.01):**
  - Implements Firebase Cloud Messaging.
  - The app now requests `POST_NOTIFICATIONS` permission on startup (Android 13+).
  - The user's FCM token is now saved to their `fcmToken` field in Firestore on login.
  - A new `MyFirebaseMessagingService` is added to receive and display notifications when the app is in the background.