### PR TITLE
Finalize Entrant Profile, History, and Deletion Features (US 01.02.xx)

### DIFF
--- a/code/.idea/deploymentTargetSelector.xml
+++ b/code/.idea/deploymentTargetSelector.xml
@@ -5,12 +5,6 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="Tests in 'com.example.fairchance.ui'">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="Tests in 'com.example.fairchance'">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/code/app/src/main/java/com/example/fairchance/ui/adapters/EventHistoryAdapter.java
+++ b/code/app/src/main/java/com/example/fairchance/ui/adapters/EventHistoryAdapter.java
@@ -1,6 +1,7 @@
 package com.example.fairchance.ui.adapters;
 
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,6 +12,7 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import com.example.fairchance.R;
 import com.example.fairchance.models.EventHistoryItem;
+import com.example.fairchance.ui.EventDetailsActivity;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Locale;
@@ -103,6 +105,13 @@ public class EventHistoryAdapter extends RecyclerView.Adapter<EventHistoryAdapte
                     tvStatus.setBackgroundColor(Color.GRAY);
                     break;
             }
+
+            // FIX: Add click listener to launch EventDetailsActivity (US 01.02.03, Criterion 5)
+            itemView.setOnClickListener(v -> {
+                Intent intent = new Intent(context, EventDetailsActivity.class);
+                intent.putExtra("EVENT_ID", item.getEventId());
+                context.startActivity(intent);
+            });
         }
     }
 }

--- a/code/app/src/main/java/com/example/fairchance/ui/fragments/HistoryFragment.java
+++ b/code/app/src/main/java/com/example/fairchance/ui/fragments/HistoryFragment.java
@@ -19,6 +19,7 @@ import com.example.fairchance.EventRepository;
 import com.example.fairchance.R;
 import com.example.fairchance.models.EventHistoryItem;
 import com.example.fairchance.ui.adapters.EventHistoryAdapter;
+import com.google.firebase.firestore.ListenerRegistration;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ public class HistoryFragment extends Fragment {
     private EventHistoryAdapter historyAdapter;
     private List<EventHistoryItem> historyList = new ArrayList<>();
     private EventRepository eventRepository;
+    private ListenerRegistration eventHistoryRegistration; // FIX: Added field for listener registration
 
     private ProgressBar progressBar;
     private TextView emptyView;
@@ -67,12 +69,27 @@ public class HistoryFragment extends Fragment {
     }
 
     /**
+     * FIX: Cleans up the real-time listener when the fragment's view is destroyed.
+     * (Part of US 01.02.03 Criterion 3 cleanup)
+     */
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (eventHistoryRegistration != null) {
+            eventHistoryRegistration.remove();
+            Log.d(TAG, "Event history listener removed.");
+        }
+    }
+
+
+    /**
      * Fetches the user's complete event history from the EventRepository
-     * and populates the RecyclerView.
+     * and populates the RecyclerView. (Now uses a real-time listener for US 01.02.03)
      */
     private void loadHistory() {
         showLoading(true);
-        eventRepository.getEventHistory(new EventRepository.EventHistoryListCallback() {
+        // FIX: Replaced one-time call with real-time listener and stored registration
+        eventHistoryRegistration = eventRepository.getEventHistory(new EventRepository.EventHistoryListCallback() {
             @Override
             public void onSuccess(List<EventHistoryItem> items) {
                 showLoading(false);


### PR DESCRIPTION
This pull request marks the completion of the Entrant's profile management and event history user stories. The main focus was refactoring the event history feature for data dynamism and enhancing navigation.

### Key Changes & Fixes

- **Dynamic History (US 01.02.03):** The user's event history list now updates in real-time by replacing the one-time fetch (`.get()`) with a **Firestore real-time listener** (`addSnapshotListener`).
- **History Navigation (US 01.02.03):** Tapping any item in the history list now correctly navigates the user to the corresponding `EventDetailsActivity`.
- **Profile Functionality Confirmed (US 01.02.01, 01.02.02, 01.02.04):** Confirmed and verified the implementation for user registration, profile updates (name/email/phone/notifications), and irreversible profile/data deletion.